### PR TITLE
Fixed en passant move generation bug when pawn on b7

### DIFF
--- a/src/Chess.php
+++ b/src/Chess.php
@@ -906,7 +906,7 @@ class Chess
 						if ($this->board[$square]['color'] === $them) {
 							$addMove($us, $this->board, $moves, $i, $square, self::BITS['CAPTURE']);
 						}
-					} else if ($square == $this->epSquare) { // get epSquare from enemy
+					} else if ($square === $this->epSquare) { // get epSquare from enemy
 						$addMove($us, $this->board, $moves, $i, $this->epSquare, self::BITS['EP_CAPTURE']);
 					}
 				}

--- a/test/PerftTest.php
+++ b/test/PerftTest.php
@@ -62,4 +62,10 @@ class PerftTest extends \PHPUnit_Framework_TestCase
 		//~ $this->assertSame($chess->perft(3), 89890);
 	}
 	
+	// Tests that square '0' cannot be confused for the EP square when EP square is null
+    public function test7()
+    {
+	   $chess = new ChessPublicator('8/RPP5/8/3k4/5Bp1/6Pp/P4P1P/5K2 w - - 1 42');
+	   $this->assertSame($chess->perft(1), 26);
+	}
 }


### PR DESCRIPTION
I discovered this bug when playing a game that involved the position:

8/RPP5/8/3k4/5Bp1/6Pp/P4P1P/5K2 w - - 1 42

It turns out that the generateMoves() method tries to create a b7-a8 move because it thinks that square a8 (internally held as square zero) is the en passant square which is internally set as null. Just using the === operator avoids this problem.

I added a perft test that will fail with a Error status with the existing code, but passes with the change.

Hope that helps,
Chris